### PR TITLE
add link cliche plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,9 @@ Transformers can be asynchronous, in which case `next` must be invoked
 
 ## List of Plugins
 
+*   [retext-cliches](https://github.com/dunckr/retext-cliches)
+    — Check phrases for cliches;
+
 *   [retext-directionality](https://github.com/wooorm/retext-directionality)
     — (**[demo](http://wooorm.github.io/retext-directionality/)**)
     — Detect the direction text is written in;


### PR DESCRIPTION
I made [this](https://github.com/dunckr/retext-cliches) plugin for checking for cliches.

Any thoughts about it would be cool!

Might want to hold off merging in until I can figure out how to get my travis test to pass on every version node though.

Cheers