### PR TITLE
add overuse

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,9 @@ Transformers can be asynchronous, in which case `next` must be invoked
 *   [`wooorm/retext-profanities`](https://github.com/wooorm/retext-profanities)
     — Check profane and vulgar wording;
 
+*   [`dunckr/retext-overuse`](https://github.com/dunckr/retext-overuse)
+    — Check words for overuse;
+
 *   [`wooorm/retext-readability`](https://github.com/wooorm/retext-readability)
     — Check readability;
 


### PR DESCRIPTION
Added [this](https://github.com/dunckr/retext-overuse) to check for the overuse of words and provide synonyms. 

There are probably better dictionaries available but was good enough for my use-case.

Thanks!